### PR TITLE
Update SERVICE_NAME to reflect new  service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ spec:
           - name: SECRET_KEY_BASE
             value: super-secret-key-base
           - name: SERVICE_NAME
-            value: el-kube.default.svc.cluster.local
+            value: el-kube-private.default.svc.cluster.local
         resources: {}
         securityContext:
           privileged: false

--- a/k8s/el-kube.yaml
+++ b/k8s/el-kube.yaml
@@ -40,7 +40,7 @@ spec:
           - name: SECRET_KEY_BASE
             value: super-secret-key-base
           - name: SERVICE_NAME
-            value: el-kube.default.svc.cluster.local
+            value: el-kube-private.default.svc.cluster.local
         resources: {}
         securityContext:
           privileged: false


### PR DESCRIPTION
Looks like a recent change to `el-kube-private-svc` broke how peerage connected things together. This fixes it.